### PR TITLE
docs: Some headers lacked space for markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,37 @@
-#Vulture: A game engine using the Vulkan API
+# Vulture: A game engine using the Vulkan API
 
-##Table of Contents
+## Table of Contents
 * [Requirements](#requirements)
 * [Environment](#environment)
 * [Building and Running](#building-and-running)
 * [Vulkan Coding Tips](#vulkan-coding-tips)
 * [Known Issues](#known-issues)
   
-##Requirements
+## Requirements
 
-###Linux:
+### Linux:
 
 1. CMake
 2. LunarG Vulkan SDK for Linux (64-bit)
 3. g++ (haven't tested clang)
 4. Xlib or XCB (both libraries and header files)
 
-###Windows:
+### Windows:
 
 1. CMake
 2. LunarG Vulkan SDK for Windows (64-bit)
 3. Visual Studio (tested for 2015 only)
 
 
-##Environment
+## Environment
 
-###Linux
+### Linux
 
 `VULKAN_SDK=<path_to_lunarg_vulkan_sdk>/x86_64`
 
 `VK_LAYER_PATH=$VULKAN_SDK/etc/explicit_layer.d`
 
-###Windows
+### Windows
 
 `VULKAN_SDK=<path_to_lunarg_vulkan_sdk>`
 
@@ -39,7 +39,7 @@ Update registry to point to Vulkan SDK layer manifests (the Windows installer
   should take care of this for you)
 
 
-##Building and Running
+## Building and Running
 
 There are 2 demos you can run: 
 
@@ -49,18 +49,18 @@ for output (you should see a ton of 'LMAO's and 'XDXD's).
 **graphics** is the more interesting of the 2. It will trigger the graphics pipeline that will 
 render graphics to your screen.
 
-###Linux
+### Linux
 
-#####From the Terminal:
+##### From the Terminal:
 1. cd into project root (same level as CMakeLists.txt)
 2. cmake -H. -Bbuild
 3. cd build
 4. make
 5. ./\<demo>
 
-###Windows (using Visual Studio 2015)
+### Windows (using Visual Studio 2015)
 
-#####From Developer Command Prompt (_Not_ the Windows command prompt):
+##### From Developer Command Prompt (_Not_ the Windows command prompt):
 1. cd into project root (same level as CMakeLists.txt)
 2. cmake -H. -Bbuild -G"Visual Studio 14 2015 Win64"
 3. cd build
@@ -68,11 +68,11 @@ render graphics to your screen.
 5. Debug\\\<demo>.exe
 
 
-##Vulkan coding tips
+## Vulkan coding tips
 Enabling the standard validation layer is a great way to uncover bugs in
    your code during development.
 
 
-##Known Issues
+## Known Issues
 As of SDK version 1.0.37.0 the VK_KHR_display extension is not supported,
    which means true fullscreen is not supported yet.


### PR DESCRIPTION
Some of the header titles in the readme file lack a space
- `#Vulture: A game engine using the Vulkan API` when it should be 
- `# Vulture: A game engine using the Vulkan API`
 the extra space changes 
#Vulture
to look like
# Vulture

That pesky space was preventing the headers from properly rendering in markdown.